### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var sparkWallet, _ = fs.Sub(static, "spark-wallet/client/dist")
 func main() {
 	p := plugin.Plugin{
 		Name:    "sparko",
-		Version: "v2.8",
+		Version: "v2.9",
 		Options: []plugin.Option{
 			{"sparko-host", "string", "127.0.0.1", "http(s) server listen address"},
 			{"sparko-port", "string", DEFAULTPORT, "http(s) server port"},


### PR DESCRIPTION
Noticed when initialized that the current version of the plugin doesn't reflect the current tag version. I updated it to 2.9 to match the tag, but that would require moving the existing tag. I guess this could be updated to 2.10 and a new version cut. Let me know what you think.